### PR TITLE
Add cmid to Back Up File Name (Issue #40)

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -189,7 +189,7 @@ class controller {
         if ($this->get_string_length($cleanname) > self::MAX_FILENAME) {
             $cleanname = $this->get_sub_string($cleanname, 0, self::MAX_FILENAME) . '_';
         }
-        $filename = sprintf('%s-%s.mbz', $cleanname, date('Ymd-His'));
+        $filename = sprintf('%s-%s-%s.mbz', $cmid, $cleanname, date('Ymd-His'));
 
         // backup the module into the predefined area
         //    - user/backup ... if userdata not included


### PR DESCRIPTION
Previously, backup file name of course module is composed by module name and backup timestamp, which leads to filename duplication and causes malfunction in restoration as described in issue #40.
This pull request fixes the problem by add course module id (cmid) to file name for creating uniqueness.