### PR TITLE
Fixes bug on admin setting which may change the setting name.

### DIFF
--- a/lib/settingslib.php
+++ b/lib/settingslib.php
@@ -164,9 +164,9 @@ class admin_setting_configmulticheckboxqtypes extends admin_setting_configmultic
         $qtypenames = array_map(function($qtype) {
             return $qtype->local_name();
         }, $qtypes);
-        foreach (question_bank::sort_qtype_array($qtypenames) as $name => $label) {
-            $choices[$name] = $label;
-            $icons[$name] = ' ' . $OUTPUT->pix_icon('icon', '', $qtypes[$name]->plugin_name()) . ' ';
+        foreach (question_bank::sort_qtype_array($qtypenames) as $qtypename => $label) {
+            $choices[$qtypename] = $label;
+            $icons[$qtypename] = ' ' . $OUTPUT->pix_icon('icon', '', $qtypes[$qtypename]->plugin_name()) . ' ';
         }
         parent::__construct($name, $visiblename, $description, $defaultsetting, $choices, $icons);
     }


### PR DESCRIPTION
Hello,

Adding this PR for your consideration.

We're getting issues with the setting for the qtype work around multi select. It would sometimes create a loop between admin/index.php and admin/upgradesettings.php

And the settings page would not show the correct qtype setting name, but rather the last qtype on the list.
![truefalse](https://user-images.githubusercontent.com/1523388/83179176-41cc0280-a0e7-11ea-819a-d0e83d136281.png)

I think using the same variable name as a method param and in the for loop is causing this.

I hope it helps.