### PR TITLE
Fix for issue#42: error/setting_locked_by_config (??)

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -234,7 +234,10 @@ class controller {
         $plan = $controller->get_plan();
         foreach ($settings as $name => $value) {
             if ($plan->setting_exists($name)) {
-                $plan->get_setting($name)->set_value($value);
+                $oldvalue = $plan->get_setting($name)->get_value();
+                if($value != $oldvalue){
+                    $plan->get_setting($name)->set_value($value);
+                }
             }
         }
         $plan->get_setting('filename')->set_value($filename);


### PR DESCRIPTION
Code is throwing exception when it's trying to set some backup setting which is locked,
even if the setting's locked value is the same as it is trying to set.