### PR TITLE
https://github.com/donhinkelman/moodle-block_sharing_cart/issues/42

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Change Log
 ----------
 * 3.8, release 16   2020.08.24
     * Make the backup support check use the built in Moodle function and secure the module class.
+    * Fix issue #42 - Setting locked by config. Avoid copying locked settings.
 * 3.8, release 15   2020.08.03
     * Remove a Sharing Cart item if the corresponding backup file is removed from the "User private backup area"
 * 3.8, release 14   2020.07.31

--- a/classes/controller.php
+++ b/classes/controller.php
@@ -28,6 +28,7 @@ use backup_controller;
 use block_sharing_cart\exceptions\no_backup_support_exception;
 use restore_controller;
 use stdClass;
+use base_setting;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -265,7 +266,12 @@ class controller {
         $plan = $controller->get_plan();
         foreach ($settings as $name => $value) {
             if ($plan->setting_exists($name)) {
-                $plan->get_setting($name)->set_value($value);
+                $current_setting = $plan->get_setting($name);
+                // If locked
+                if (base_setting::NOT_LOCKED !== $current_setting->get_status()) {
+                    continue;
+                }
+                $current_setting->set_value($value);
             }
         }
         $plan->get_setting('filename')->set_value($filename);

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2020082400;
+$plugin->version = 2020082401;
 $plugin->requires = 2018120300; // Moodle 3.6
 $plugin->component = 'block_sharing_cart';
 $plugin->release = '3.8, release 16';


### PR DESCRIPTION
Fix issue #42 - Setting locked by config. Avoid copying locked settings.