### PR TITLE
Fix Issue #63 - Include Availability in Section Backup

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -326,6 +326,7 @@ class controller {
             $sharing_cart_section->name = get_section_name($section->course, $section->section);
             $sharing_cart_section->summary = $section->summary;
             $sharing_cart_section->summaryformat = $section->summaryformat;
+            $sharing_cart_section->availability = $section->availability;
             $sc_section_id = $DB->insert_record('block_sharing_cart_sections', $sharing_cart_section);
             $sc_section_id = $sc_section_id ? $sc_section_id : 0;
 
@@ -559,6 +560,7 @@ class controller {
                 $restored_section->name = $overwrite_section->name;
                 $restored_section->summary = $overwrite_section->summary;
                 $restored_section->summaryformat = $overwrite_section->summaryformat;
+                $restored_section->availability = $overwrite_section->availability;
 
                 course_update_section($courseid, $original_restored_section, $restored_section);
             }

--- a/db/install.xml
+++ b/db/install.xml
@@ -43,6 +43,7 @@
                 <FIELD NAME="name" TYPE="char" LENGTH="255" NOTNULL="true" SEQUENCE="false" PREVIOUS="id"/>
                 <FIELD NAME="summary" TYPE="text" NOTNULL="false" SEQUENCE="false" PREVIOUS="name"/>
                 <FIELD NAME="summaryformat" TYPE="int" LENGTH="2" NOTNULL="true" SEQUENCE="false" DEFAULT="0" PREVIOUS="summary"/>
+                <FIELD NAME="availability" TYPE="text" NOTNULL="false" SEQUENCE="false" COMMENT="Availability restrictions for viewing this section, in JSON format. Null if no restrictions."/>
             </FIELDS>
             <KEYS>
                 <KEY NAME="id" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -146,5 +146,16 @@ function xmldb_block_sharing_cart_upgrade($oldversion = 0) {
         }
     }
 
+    if ($oldversion < 2020112000) {
+        $table = new xmldb_table('block_sharing_cart_sections');
+
+        if ($dbman->table_exists($table)) {
+            $field_availability = new xmldb_field('availability', XMLDB_TYPE_TEXT, null, null, false, false, null, 'summaryformat');
+            $dbman->add_field($table, $field_availability);
+        }
+
+        upgrade_block_savepoint(true, 2020112000, 'sharing_cart');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -146,15 +146,17 @@ function xmldb_block_sharing_cart_upgrade($oldversion = 0) {
         }
     }
 
-    if ($oldversion < 2020112000) {
+    if ($oldversion < 2020112001) {
         $table = new xmldb_table('block_sharing_cart_sections');
 
         if ($dbman->table_exists($table)) {
             $field_availability = new xmldb_field('availability', XMLDB_TYPE_TEXT, null, null, false, false, null, 'summaryformat');
-            $dbman->add_field($table, $field_availability);
+            if (!$dbman->field_exists($table, $field_availability)) {
+                $dbman->add_field($table, $field_availability);
+            }
         }
 
-        upgrade_block_savepoint(true, 2020112000, 'sharing_cart');
+        upgrade_block_savepoint(true, 2020112001, 'sharing_cart');
     }
 
     return true;

--- a/lang/en/block_sharing_cart.php
+++ b/lang/en/block_sharing_cart.php
@@ -82,13 +82,13 @@ $string['requireajax'] = 'Sharing Cart requires AJAX';
 
 $string['variouscourse'] = 'from various courses';
 
-$string['section_name_conflict'] = 'Section title conflict';
-$string['conflict_description'] = 'Do you want to overwrite section title in course?';
-$string['conflict_description_note'] = '*Section summary formats (font color, images, etc.) will appear after copied to course.';
+$string['section_name_conflict'] = 'Section conflict';
+$string['conflict_description'] = 'Do you want to overwrite section information to course?';
+$string['conflict_description_note'] = '*Section summary formats (font color, images, etc.) and availability settings will overwrite after copied to course.';
 $string['restore_heavy_load_warning_message'] = 'Load time are longer, because more than 10 activities/resources are being processed.';
 $string['backup_heavy_load_warning_message'] = 'If section contains several activites, processing time will be longer.';
-$string['conflict_no_overwrite'] = 'Keep the current section title <strong>"{$a}"</strong>';
-$string['conflict_overwrite_title'] = 'Change section title to <strong>"{$a}"</strong>';
+$string['conflict_no_overwrite'] = 'Keep the current section name and settings <strong>"{$a}"</strong>';
+$string['conflict_overwrite_title'] = 'Overwrite section name and settings to <strong>"{$a}"</strong>';
 $string['conflict_submit'] = 'Continue';
 
 $string['folder_string'] = 'Folder:';

--- a/lang/es/block_sharing_cart.php
+++ b/lang/es/block_sharing_cart.php
@@ -79,12 +79,12 @@ $string['requireajax'] = 'Recursos comparridos requiere AJAX';
 
 $string['variouscourse'] = 'desde cursos varios';
 
-$string['section_name_conflict'] = 'Conflicto del título de la sección';
-$string['conflict_description'] = '¿Quiere cambiar el título de la sección en el curso?';
+$string['section_name_conflict'] = 'Conflicto de la sección';
+$string['conflict_description'] = '¿Quiere cambiar el título y la configuración de la sección en el curso?';
 $string['conflict_description_note'] =
-        '*Los formatos de la descripción del título (colores, imágenes, etc.) se aparecerán después de copiar al curso.';
+        '*Los formatos de la descripción del título (colores, imágenes, etc.) y la configuración se aparecerán después de copiar al curso.';
 $string['restore_heavy_load_warning_message'] = 'Load time are longer, because more than 10 activities/resources are being processed. (Translation missing)';
 $string['backup_heavy_load_warning_message'] = 'If section contains several activites, processing time will be longer. (Translation missing)';
-$string['conflict_no_overwrite'] = 'Mantener utilizando <strong>"{$a}"</strong>';
-$string['conflict_overwrite_title'] = 'Cambiar el título a <strong>"{$a}"</strong>';
+$string['conflict_no_overwrite'] = 'Mantener utilizando el título y la configuración de <strong>"{$a}"</strong>';
+$string['conflict_overwrite_title'] = 'Cambiar el título y la configuración a <strong>"{$a}"</strong>';
 $string['conflict_submit'] = 'Continuar';

--- a/lang/ja/block_sharing_cart.php
+++ b/lang/ja/block_sharing_cart.php
@@ -79,11 +79,11 @@ $string['requireajax'] = 'AJAX が有効になっていません';
 
 $string['variouscourse'] = '複数のコースから';
 
-$string['section_name_conflict'] = 'トピック名の選択';
-$string['conflict_description'] = 'コースのトピック名を上書きしますか？';
-$string['conflict_description_note'] = '※トピックの説明のフォーマット（テキストの色、画像など）がコースコピー後に表現する。';
+$string['section_name_conflict'] = '上書きするトピックの選択';
+$string['conflict_description'] = 'コースのトピックを上書きしますか？';
+$string['conflict_description_note'] = '※トピックの説明のフォーマット（テキストの色、画像など）と設定がコースコピー後に表現する。';
 $string['restore_heavy_load_warning_message'] = 'Load time are longer, because more than 10 activities/resources are being processed. (Translation missing)';
 $string['backup_heavy_load_warning_message'] = 'If section contains several activites, processing time will be longer. (Translation missing)';
-$string['conflict_no_overwrite'] = 'トピック名を変更しない。<strong>「{$a}」</strong>のままにする。';
-$string['conflict_overwrite_title'] = 'タイトルを<strong>「{$a}」</strong>に変更する。';
+$string['conflict_no_overwrite'] = 'トピック名と設定を変更しない。<strong>「{$a}」</strong>のままにする。';
+$string['conflict_overwrite_title'] = 'タイトルと設定を<strong>「{$a}」</strong>に変更する。';
 $string['conflict_submit'] = '続く';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2020090100;
+$plugin->version = 2020112000;
 $plugin->requires = 2018120300; // Moodle 3.6
 $plugin->component = 'block_sharing_cart';
 $plugin->release = '3.8, release 17';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version = 2020112000;
+$plugin->version = 2020112001;
 $plugin->requires = 2018120300; // Moodle 3.6
 $plugin->component = 'block_sharing_cart';
 $plugin->release = '3.8, release 17';


### PR DESCRIPTION
Fix Issue #63: Including availability settings into section backup

- Updated version number in `version.php` as database structure has been changed.
- Add field `availability` to table `block_sharing_cart_sections`, for storing JSON data of cloned section from table `course_sections.availability`
- `availability` will be restored, only if "overwrite section" is selected (`classes/controller.php#L563`)
  - (First reason, it is not able to retreive section ID (`block_sharing_cart_sections.id`) from clicked directory in cart if overwrite option is not selected, because section ID was not orignially included to directory bullet in `controller::render_tree`)
  - (Secondly, a directory in sharing cart can be consisted of items originated from different sections, for this reason, in the "overwrite section confirmation" page will let users to make sure which section title and availability section will be restore)
- Updated text strings in "section conflict confirmation" page, from "overwrite section name" to "overwrite section name and settings" to avoid confusion.