### PR TITLE
Cover block_sharing_cart_plugins table by a metadata provider

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -147,6 +147,12 @@ class provider implements
             'weight' => 'privacy:metadata:block_sharing_cart:weight',
         ], 'privacy:metadata:block_sharing_cart');
 
+        $collection->add_database_table('block_sharing_cart_plugins', [
+            'plugin' => 'privacy:metadata:block_sharing_cart_plugins:plugin',
+            'userid' => 'privacy:metadata:block_sharing_cart_plugins:userid',
+            'data' => 'privacy:metadata:block_sharing_cart_plugins:data',
+        ], 'privacy:metadata:block_sharing_cart_plugins');
+
         return $collection;
     }
 

--- a/lang/en/block_sharing_cart.php
+++ b/lang/en/block_sharing_cart.php
@@ -113,3 +113,7 @@ $string['privacy:metadata:block_sharing_cart:modtext'] = 'The title of the activ
 $string['privacy:metadata:block_sharing_cart:ctime'] = 'Created time';
 $string['privacy:metadata:block_sharing_cart:tree'] = 'The title of sharing cart folder that display in the block';
 $string['privacy:metadata:block_sharing_cart:weight'] = 'Order of items, sorting in ascending order';
+$string['privacy:metadata:block_sharing_cart_plugins'] = 'Sharing cart plugins data is stored here';
+$string['privacy:metadata:block_sharing_cart_plugins:plugin'] = 'The name of the plugin';
+$string['privacy:metadata:block_sharing_cart_plugins:userid'] = 'The ID of user';
+$string['privacy:metadata:block_sharing_cart_plugins:data'] = 'Sharing cart plugins data';


### PR DESCRIPTION
This is a fix for #85 