### PR TITLE
Issue donhinkelman/moodle-block_sharing_cart#83 - Copying empty sections

### DIFF
--- a/classes/renderer.php
+++ b/classes/renderer.php
@@ -88,6 +88,9 @@ class renderer {
                 $html .= self::render_dir_close();
             } else {
                 foreach ($leaf as $item) {
+                    if (!$item->modname) { // issue-83: skip rendering empty item in empty section (wnat to render only the folder)
+                        continue;
+                    }
                     $html .= self::render_item($path, $item);
                 }
             }


### PR DESCRIPTION
Fixing issue #83, copying an empty section. Previously the empty secions were not rendered in the cart because there is no items having the tree path. This fix creates an empty item (field `modname` to be an empty string) when copying an empty section to the cart.