### PR TITLE
Use $CFG->backuptempdir instead of $CFG->tempdir.'/backup'

### DIFF
--- a/classes/controller.php
+++ b/classes/controller.php
@@ -777,7 +777,7 @@ class controller {
      */
     public static function get_tempdir() {
         global $CFG;
-        $tempdir = $CFG->tempdir . '/backup';
+        $tempdir = $CFG->backuptempdir;
         if (!\check_dir_exists($tempdir, true, true)) {
             throw new exception('unexpectederror');
         }


### PR DESCRIPTION
Since Moodle 3.5 / MDL-60923, Moodle core has the $CFG->backuptempdir setting which holds the path to the backup temp dir - see https://github.com/moodle/moodle/blob/master/lib/setup.php#L199.

This plugin does not respect this setting yet. On Moodle instances where $CFG->backuptempdir is used, sharing cart might / will fail to restore backups.