### PR TITLE
Add environment.xml to check for PHP Version

### DIFF
--- a/environment.xml
+++ b/environment.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<COMPATIBILITY_MATRIX>
+  <PLUGIN name="block_sharing_cart">
+    <PHP version="7.4" level="required" />
+  </PLUGIN>
+</COMPATIBILITY_MATRIX>


### PR DESCRIPTION
Due to the plugin version in master using PHP 7.4 features it may be compatible to Moodle 3.9 as marked in plugins directory, but it needs PHP 7.4 min!
Adding the envirionment check prevents Moodle 3.9 installations from installing the plugin in PHP <7.4 environments!