### PR TITLE
Exclude badges when copy an activity and a section into the sharing cart

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,79 @@
+name: Integration & Unit test
+
+on:
+  pull_request:
+    branches:
+      - master
+
+env:
+  php: 7.4
+
+jobs:
+  PHPUnit:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            php: 7.2
+            db: mysqli
+            moodle: MOODLE_39_STABLE
+            plugin_branch: MOODLE_39_STABLE
+          - os: ubuntu-18.04
+            php: 7.3
+            db: mysqli
+            moodle: MOODLE_310_STABLE
+            plugin_branch: MOODLE_310_STABLE
+          - os: ubuntu-20.04
+            php: 7.4
+            db: mysqli
+            moodle: MOODLE_311_STABLE
+            plugin_branch: MOODLE_311_STABLE
+
+    steps:
+      - name: Setting up DB mysql
+        if: ${{ matrix.db == 'mysqli' }}
+        uses: johanmeiring/mysql-action@tmpfs-patch
+        with:
+          collation server: utf8mb4_unicode_ci
+          mysql version: 5.7
+          mysql database: test
+          mysql user: test
+          mysql password: test
+          use tmpfs: true
+
+      - name: Setting up PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Checking out code from moodle/moodle
+        uses: actions/checkout@v2
+        with:
+          repository: moodle/moodle
+          ref: ${{ matrix.moodle }}
+
+      - name: Check out code from ${{ github.repository }}
+        uses: actions/checkout@v2
+        with:
+          path: ${{ github.workspace }}/blocks/sharing_cart
+          ref: ${{ github.ref }}
+
+      - name: Lint module code
+        run:
+          find $GITHUB_WORKSPACE/blocks/sharing_cart -type f -name '*.php' -print0 | xargs -0 -n1 -P4 php -l -n | (! grep -v "No syntax errors detected" )
+
+      - name: Setting up PHPUnit
+        env:
+          dbtype: ${{ matrix.db }}
+        run: |
+          echo "pathtophp=$(which php)" >> $GITHUB_ENV # Inject installed pathtophp to env. The template config needs it.
+          cp $GITHUB_WORKSPACE/.github/workflows/config-template.php $GITHUB_WORKSPACE/config.php
+          mkdir $GITHUB_WORKSPACE/../moodledata
+          sudo locale-gen en_AU.UTF-8
+          php $GITHUB_WORKSPACE/admin/tool/phpunit/cli/init.php --no-composer-self-update
+      - name: Running PHPUnit tests
+        env:
+          dbtype: ${{ matrix.db }}
+        run: $GITHUB_WORKSPACE/vendor/bin/phpunit -c $GITHUB_WORKSPACE/phpunit.xml --testsuite=block_sharing_cart_testsuite -v --testdox

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Warning: PHP versions 7.2 and older are deprecated, and will cause problems, unr
 
 Change Log
 ----------
+* 3.10, release 9 2022.02.25
+  * Fixed plugin unintended copy badges from a course, when user copy an activity and a section.
 * 3.10, release 8 2021.09.29
   * Tested and passed a fix for Issue #101: Exception Call to a member function get_tasks() on null
 * 3.10, release 7  2021.08.05

--- a/block_sharing_cart.php
+++ b/block_sharing_cart.php
@@ -103,17 +103,31 @@ class block_sharing_cart extends block_base {
         $this->page->requires->jquery();
 		$this->page->requires->js_call_amd('block_sharing_cart/script', 'init');
         $this->page->requires->strings_for_js(
-                array('yes', 'no', 'ok', 'cancel', 'error', 'edit', 'move', 'delete', 'movehere'),
-                'moodle'
+            ['yes', 'no', 'ok', 'cancel', 'error', 'edit', 'move', 'delete', 'movehere'],
+            'moodle'
         );
         $this->page->requires->strings_for_js(
-                array('copyhere', 'notarget', 'backup', 'restore', 'movedir', 'clipboard',
-                        'confirm_backup', 'confirm_backup_section', 'confirm_userdata',
-                        'confirm_userdata', 'confirm_delete', 'clicktomove', 'folder_string',
-                        'activity_string', 'delete_folder', 'modal_checkbox',
-                        'modal_confirm_backup', 'modal_confirm_delete', 'backup_heavy_load_warning_message'
-                ),
-                __CLASS__
+            [
+                'copyhere',
+                'notarget',
+                'backup',
+                'restore',
+                'movedir',
+                'clipboard',
+                'confirm_backup',
+                'confirm_backup_section',
+                'confirm_userdata',
+                'confirm_delete',
+                'clicktomove',
+                'folder_string',
+                'activity_string',
+                'delete_folder',
+                'modal_checkbox',
+                'modal_confirm_backup',
+                'modal_confirm_delete',
+                'backup_heavy_load_warning_message',
+            ],
+            __CLASS__
         );
 
         $footer = '';
@@ -206,5 +220,4 @@ class block_sharing_cart extends block_base {
     private function is_special_version(): bool {
         return version_compare(moodle_major_version(), '3.2') === 1;
     }
-
 }

--- a/classes/controller.php
+++ b/classes/controller.php
@@ -193,7 +193,14 @@ class controller {
      * @global \moodle_database $DB
      * @global object $USER
      */
-    public function backup(int $cmid, bool $has_userdata, int $course, int $section = 0): int {
+    public function backup(
+        int $cmid,
+        bool $has_userdata,
+        int $course,
+        int $section = 0,
+        bool $include_badges = false
+    ): int {
+
         global $USER, $CFG; //$CFG IS USED, DO NOT REMOVE IT
 
         if (module::has_backup($cmid, $course) === false) {
@@ -232,7 +239,8 @@ class controller {
                 'logs' => false,
                 'grade_histories' => false,
                 'users' => false,
-                'anonymize' => false
+                'anonymize' => false,
+                'badges' => $include_badges
         ];
         if ($has_userdata && \has_capability('moodle/backup:userinfo', $context)) {
             $settings['users'] = true;
@@ -395,11 +403,12 @@ class controller {
                         continue;
                     }
 
-                    if ($userdata && $this->is_userdata_copyable((int)$module->id)) {
-                        $itemids[] = $this->backup((int)$module->id, true, $course, $sc_section_id);
-                    } else {
-                        $itemids[] = $this->backup((int)$module->id, false, $course, $sc_section_id);
-                    }
+                    $itemids[] = $this->backup(
+                        (int)$module->id,
+                        $userdata && $this->is_userdata_copyable((int)$module->id),
+                        $course,
+                        $sc_section_id
+                    );
                 }
             } else {
                 $itemids[] = $this->backup_emptysection($course, $sc_section_id);

--- a/classes/tests/sharing_chart_testcase.php
+++ b/classes/tests/sharing_chart_testcase.php
@@ -8,7 +8,11 @@
 
 namespace block_sharing_cart\tests;
 
+use advanced_testcase;
 use block_sharing_cart\record;
+use dml_exception;
+use moodle_database;
+use stdClass;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -16,17 +20,24 @@ defined('MOODLE_INTERNAL') || die();
  * Unit test tool
  * @package block_sharing_cart\tests
  */
-trait sharing_chart_test_tools {
+abstract class sharing_chart_testcase extends advanced_testcase {
+
+    /**
+     * @inheritDoc
+     */
+    protected function setUp(): void {
+        $this->resetAfterTest();
+    }
 
     /**
      * Get course section with name
      * @param $course
      * @param int $section
      * @return object
-     * @throws \dml_exception
+     * @throws dml_exception
      */
-    private function get_course_section($course, int $section): object {
-        $record = self::db()->get_record('course_sections', [
+    protected function get_course_section($course, int $section): object {
+        $record = $this->db()->get_record('course_sections', [
             'course' => $course->id,
             'section' => $section
         ]);
@@ -39,40 +50,40 @@ trait sharing_chart_test_tools {
     /**
      * @param int $id
      * @return int
-     * @throws \dml_exception
+     * @throws dml_exception
      */
-    private function get_sharing_cart_weight(int $id): int {
-        return self::db()->get_field(record::TABLE, 'weight', ['id' => $id]);
+    protected function get_sharing_cart_weight(int $id): int {
+        return $this->db()->get_field(record::TABLE, 'weight', ['id' => $id]);
     }
 
     /**
      * @param string $module_name
      * @param string $tree
-     * @return bool|false|mixed|\stdClass
-     * @throws \dml_exception
+     * @return bool|false|mixed|stdClass
+     * @throws dml_exception
      */
-    private function get_sharing_cart_by_module(string $module_name, string $tree = '') {
-        return self::db()->get_record(record::TABLE, ['modname' => $module_name, 'tree' => $tree]);
+    protected function get_sharing_cart_by_module(string $module_name, string $tree = '') {
+        return $this->db()->get_record(record::TABLE, ['modname' => $module_name, 'tree' => $tree]);
     }
 
     /**
      * Get a single sharing cart entity
      * @param array $conditions
      * @return object
-     * @throws \dml_exception
+     * @throws dml_exception
      */
-    private function get_sharing_cart_entity(array $conditions = []): object {
-        return self::db()->get_record('block_sharing_cart', $conditions);
+    protected function get_sharing_cart_entity(array $conditions = []): object {
+        return $this->db()->get_record('block_sharing_cart', $conditions);
     }
 
     /**
      * Get sharing cart entities
      * @param array $conditions
      * @return array
-     * @throws \dml_exception
+     * @throws dml_exception
      */
-    private function get_sharing_cart_entities(array $conditions = []): array {
-        return self::db()->get_records('block_sharing_cart', $conditions);
+    protected function get_sharing_cart_entities(array $conditions = []): array {
+        return $this->db()->get_records('block_sharing_cart', $conditions);
     }
 
     /**
@@ -81,7 +92,7 @@ trait sharing_chart_test_tools {
      * @param string $role
      * @param object[] $users
      */
-    private function enrol_users($course, array $users = null, string $role = 'editingteacher'): void {
+    protected function enrol_users($course, array $users = null, string $role = 'editingteacher'): void {
         global $USER;
 
         // Add current user to enrollment
@@ -98,7 +109,7 @@ trait sharing_chart_test_tools {
      * Set session via GET method
      * @param object $user
      */
-    private function set_session_key(object $user): void {
+    protected function set_session_key(object $user): void {
         // Set current user
         self::setUser($user);
 
@@ -115,7 +126,7 @@ trait sharing_chart_test_tools {
      * @param array|null $options
      * @return object
      */
-    private function create_assignment($course, int $section = 0, array $properties = [], array $options = null): object {
+    protected function create_assignment($course, int $section = 0, array $properties = [], array $options = null): object {
         return $this->create_module('assign', $course, $section, $properties, $options);
     }
 
@@ -127,7 +138,7 @@ trait sharing_chart_test_tools {
      * @param array|null $options
      * @return object
      */
-    private function create_module(string $name, $course, int $section = 0, array $properties = [], array $options = null): object {
+    protected function create_module(string $name, $course, int $section = 0, array $properties = [], array $options = null): object {
         $properties['course'] = $course->id;
 
         if (!isset($properties['section'])) {
@@ -142,7 +153,7 @@ trait sharing_chart_test_tools {
      * @param array|null $properties
      * @return object
      */
-    private function create_user(array $properties = null): object {
+    protected function create_user(array $properties = null): object {
         return self::getDataGenerator()->create_user($properties);
     }
 
@@ -151,7 +162,7 @@ trait sharing_chart_test_tools {
      * @param array $properties
      * @return object
      */
-    private function create_course(array $properties = ['section' => 4]): object {
+    protected function create_course(array $properties = ['section' => 4]): object {
         return self::getDataGenerator()->create_course($properties);
     }
 
@@ -161,9 +172,9 @@ trait sharing_chart_test_tools {
      * @param int $section
      * @param null $filename
      * @return object
-     * @throws \dml_exception
+     * @throws dml_exception
      */
-    private function create_sharing_chart_record($user, $course, $section = 0, $filename = null): object {
+    protected function create_sharing_chart_record($user, $course, $section = 0, $filename = null): object {
         $filename = $filename ?? md5(random_bytes(16));
         $modname = md5(random_bytes(16));
         $modicon = md5(random_bytes(16));
@@ -182,16 +193,16 @@ trait sharing_chart_test_tools {
             'tree' => '',
         ];
 
-        $id = self::db()->insert_record('block_sharing_cart', (object)$params);
+        $id = $this->db()->insert_record('block_sharing_cart', (object)$params);
         $params['id'] = $id;
         return (object)$params;
     }
 
     /**
      * Get moodle database
-     * @return \moodle_database
+     * @return moodle_database
      */
-    private static function db(): \moodle_database {
+    protected function db(): moodle_database {
         global $DB;
         return $DB;
     }

--- a/rest.php
+++ b/rest.php
@@ -118,16 +118,5 @@ try {
         );
     }
 
-	/**
-	 * If logger exists - we log some stuff
-	 */
-    if(class_exists(mysql_logger::class)){
-    	try{
-		    $logger = new mysql_logger();
-		    $logger->log($ex->getMessage(), $ex);
-	    }
-	    catch(\Exception $e){}
-    }
-
     echo json_encode($json);
 }

--- a/tests/integration/controller/controller_test.php
+++ b/tests/integration/controller/controller_test.php
@@ -1,13 +1,20 @@
 <?php
 
+namespace block_sharing_cart\integration\controller;
+
+use block_sharing_cart\controller;
+use block_sharing_cart\exception;
+use block_sharing_cart\record;
+use block_sharing_cart\tests\sharing_chart_testcase;
+use dml_exception;
+use moodle_exception;
 
 defined('MOODLE_INTERNAL') || die();
 
 /**
  * Testing controller functionality
  */
-class block_sharing_cart_controller_testcase extends advanced_testcase {
-    use \block_sharing_cart\tests\sharing_chart_test_tools;
+class controller_test extends sharing_chart_testcase {
 
     /**
      * This method is called before each test.
@@ -40,7 +47,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $entities = $this->get_sharing_cart_entities(['userid' => $user->id]);
         $this->assertCount(0, $entities);
 
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup($assignment->cmid, false, $course->id);
         $controller->backup($label->cmid, false, $course->id);
         $controller->backup($forum->cmid, false, $course->id);
@@ -94,7 +101,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $entities = $this->get_sharing_cart_entities(['userid' => $user->id]);
         $this->assertCount(0, $entities);
 
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup_section($section1->id, $section1->name, false, $course->id);
         $controller->backup_section($section2->id, $section2->name, false, $course->id);
 
@@ -139,7 +146,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $entities = $this->get_sharing_cart_entities(['userid' => $user->id]);
         $this->assertCount(0, $entities);
 
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup_section($section2->id, $section2->name, false, $course->id);
         $controller->backup($assignment1->cmid, false, $course->id);
         $controller->backup($assignment2->cmid, false, $course->id);
@@ -148,8 +155,8 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $entities = $this->get_sharing_cart_entities(['userid' => $user->id]);
         $this->assertCount(3, $entities);
 
-        $copied_labels = self::db()->get_records(\block_sharing_cart\record::TABLE, ['modname' => 'label']);
-        $copied_assignments = self::db()->get_records(\block_sharing_cart\record::TABLE, ['modname' => 'assign']);
+        $copied_labels = self::db()->get_records(record::TABLE, ['modname' => 'label']);
+        $copied_assignments = self::db()->get_records(record::TABLE, ['modname' => 'assign']);
     }
 
     public function test_restore_modules_from_sharing_cart() {
@@ -166,7 +173,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $this->enrol_users($course, [$user]);
         $this->set_session_key($user);
 
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup($assignment->cmid, false, $course->id);
         $controller->backup($forum->cmid, false, $course->id);
         $controller->backup($label->cmid, false, $course->id);
@@ -226,7 +233,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
     /**
      * Test moving item in sharing cart to a new position
      *
-     * @throws \block_sharing_cart\exception
+     * @throws exception
      * @throws dml_exception
      * @throws moodle_exception
      */
@@ -244,7 +251,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $this->set_session_key($user);
 
         // Copy modules to the sharing cart
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup($forum->cmid, false, $course->id);
         $controller->backup($assignment->cmid, false, $course->id);
         $controller->backup($label->cmid, false, $course->id);
@@ -314,7 +321,7 @@ class block_sharing_cart_controller_testcase extends advanced_testcase {
         $this->enrol_users($course, [$user]);
         $this->set_session_key($user);
 
-        $controller = new \block_sharing_cart\controller();
+        $controller = new controller();
         $controller->backup($assignment->cmid, false, $course->id);
         $controller->backup($label->cmid, false, $course->id);
         $controller->backup_section($section1->id, $section1->name, false, $course->id);

--- a/tests/integration/db/upgrade_database_test.php
+++ b/tests/integration/db/upgrade_database_test.php
@@ -1,5 +1,16 @@
 <?php
 
+namespace block_sharing_cart\integration\controller;
+
+use advanced_testcase;
+use coding_exception;
+use ddl_exception;
+use ddl_field_missing_exception;
+use ddl_table_missing_exception;
+use moodle_database;
+use xmldb_field;
+use xmldb_table;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
@@ -8,7 +19,7 @@ defined('MOODLE_INTERNAL') || die();
  * Purpose of test to see if upgrade script is working correctly
  * @package block_sharing_cart\tests
  */
-class block_sharing_cart_db_testcase extends advanced_testcase {
+class upgrade_database_test extends advanced_testcase {
     private $junk_tables = [];
 
     /**
@@ -46,7 +57,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
             $this->assertContains($field->getName(), $old_column_names);
         }
 
-        $dbman = self::db()->get_manager();
+        $dbman = $this->db()->get_manager();
 
         // Change column names
         foreach ($fields as $name => $field) {
@@ -98,7 +109,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
      * @test
      */
     public function change_default_value_for_section_table() {
-        $dbman = self::db()->get_manager();
+        $dbman = $this->db()->get_manager();
         $table = $this->create_section_table();
 
         $field_name = new xmldb_field('name', XMLDB_TYPE_CHAR, 255, null, XMLDB_NOTNULL);
@@ -168,7 +179,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
             }
         }
 
-        $dbman = self::db()->get_manager();
+        $dbman = $this->db()->get_manager();
         $dbman->create_table($table);
         $this->junk_tables[$table->getName()] = $table;
         return $table;
@@ -203,7 +214,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
      * @throws ddl_table_missing_exception
      */
     private function drop_tables(...$tables) {
-        $dbman = self::db()->get_manager();
+        $dbman = $this->db()->get_manager();
 
         foreach ($tables as $table) {
             if (is_string($table)) {
@@ -224,8 +235,8 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
      */
     private function random_name($length = 16) {
         $chars = 'abcdefghijklmnopqrstuvwxyz';
-        $position = mt_rand(0, strlen($chars) - 1);
-        $first_letter = substr($chars, $position, 1);
+        $position = random_int(0, strlen($chars) - 1);
+        $first_letter = $chars[$position];
 
         return $first_letter . substr(
             bin2hex(random_bytes($length)),
@@ -239,7 +250,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
      * @return string[]
      */
     private function get_column_names(xmldb_table $table) {
-        $columns = self::db()->get_columns($table->getName());
+        $columns = $this->db()->get_columns($table->getName());
 
         if (empty($columns)) {
             return [];
@@ -254,7 +265,7 @@ class block_sharing_cart_db_testcase extends advanced_testcase {
      * Get moodle database
      * @return moodle_database
      */
-    private static function db() {
+    private function db(): moodle_database {
         global $DB;
         return $DB;
     }

--- a/tests/integration/repositories/course_repository_test.php
+++ b/tests/integration/repositories/course_repository_test.php
@@ -5,8 +5,13 @@
  * @companyinfo https://praxis.dk
  */
 
+namespace block_sharing_cart\integration\repositories;
+
 use block_sharing_cart\repositories\course_repository;
-use block_sharing_cart\tests\sharing_chart_test_tools;
+use block_sharing_cart\tests\sharing_chart_testcase;
+use coding_exception;
+use dml_exception;
+use moodle_database;
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -14,17 +19,8 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Class block_sharing_cart_course_repository_testcase
  */
-class block_sharing_cart_course_repository_testcase extends advanced_testcase
+class course_repository_test extends sharing_chart_testcase
 {
-    use sharing_chart_test_tools;
-
-    /**
-     * This method is called before each test.
-     */
-    protected function setUp(): void {
-        $this->resetAfterTest();
-    }
-
     /**
      * @throws coding_exception
      * @throws dml_exception
@@ -72,13 +68,5 @@ class block_sharing_cart_course_repository_testcase extends advanced_testcase
         $actual_course_fullnames = $repo->get_course_fullnames_by_sharing_carts([]);
 
         $this->assertEmpty($actual_course_fullnames);
-    }
-
-    /**
-     * @return moodle_database|null
-     */
-    private function db() {
-        global $DB;
-        return $DB;
     }
 }

--- a/tests/integration/storage/storage_test.php
+++ b/tests/integration/storage/storage_test.php
@@ -4,12 +4,18 @@
  * @author      Sam Møller (https://github.com/sampraxis)
  */
 
+namespace block_sharing_cart\integration\storage;
+
+use advanced_testcase;
 use block_sharing_cart\exceptions\cannot_find_file_exception;
 use block_sharing_cart\storage;
+use context_user;
+use dml_exception;
+use moodle_database;
 
 defined('MOODLE_INTERNAL') || die();
 
-class block_sharing_cart_storage_testcase extends advanced_testcase
+class storage_test extends advanced_testcase
 {
     /**
      * @inheridoc

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 /** @var stdClass $plugin */
 $plugin->component = 'block_sharing_cart';
-$plugin->version   = 2021092900;
+$plugin->version   = 2022022200;
 $plugin->requires  = 2018120300; // Moodle 3.6
-$plugin->release   = '3.10, release 8';
+$plugin->release   = '3.10, release 9';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
Fix backup/restore that unintended include badges when copy an activity or a section into the sharing cart.