### PR TITLE
Fix display of labels on bulkdelete page

### DIFF
--- a/bulkdelete.php
+++ b/bulkdelete.php
@@ -133,6 +133,10 @@ echo $OUTPUT->header();
         echo '
 		<ul class="bulk-delete-list">';
         foreach ($items as $id => $item) {
+            if ($item->modname === 'label') {
+                $item->modtext = renderer::strip_label($item->modtext);
+                $item->modtext = renderer::replace_image_with_string($item->modtext);
+            }
             echo '
 			<li class="bulk-delete-item">
 				<input type="checkbox" name="delete[' . $id . ']" checked="checked" id="delete_' . $id . '" />

--- a/classes/renderer.php
+++ b/classes/renderer.php
@@ -214,7 +214,7 @@ class renderer {
      * @param string $modtext
      * @return string
      */
-    private static function strip_label(string $modtext): string {
+    public static function strip_label(string $modtext): string {
         return strip_tags($modtext, '<img>');
     }
 
@@ -223,7 +223,7 @@ class renderer {
      * @return string
      * @throws \coding_exception
      */
-    private static function replace_image_with_string(string $modtext): string {
+    public static function replace_image_with_string(string $modtext): string {
         if (strpos($modtext, '<img') !== false) {
             $modtext = preg_replace('/<img[^>]+>/i', get_string('label_image_replaced_text', 'block_sharing_cart'), $modtext);
         }


### PR DESCRIPTION
This re-uses the display logic from the block to ensure a label has some placeholder text even if it only contains an image.

Closes #93