### PR TITLE
Fix for issue #165. Adds flex-wrap: wrap property to node-tree in custom.css to prevent overflowing content.

### DIFF
--- a/custom.css
+++ b/custom.css
@@ -1,5 +1,10 @@
 /* SHARING CART TREE START */
 
+.block_sharing_cart div.card-text ul.tree {
+    display: flex;
+    flex-wrap: wrap;
+}
+
 .block_sharing_cart div.card-text ul.tree li:hover {
     background-color: rgba(0, 0, 0, .03);
 }

--- a/custom.css
+++ b/custom.css
@@ -37,8 +37,10 @@
 .block_sharing_cart ul.tree li > div .instancename,
 .block_sharing_cart ul.tree li > div .instancename .no-overflow p {
     text-overflow: ellipsis;
-    white-space: nowrap;
+    text-align: start;
+    white-space: wrap;
     overflow: hidden;
+    overflow-wrap: anywhere;
     display: inline-block;
     margin: 2px 0 auto 0;
     width: 100%;


### PR DESCRIPTION
Cheers Don. I hope you're doing fine.
We recently made the upgrade to Moodle 4.1 and came across this issue. As far as we can tell, this small fix is enough.