### PR TITLE
Space between checkbox and icon in setting fixes #182.

### DIFF
--- a/lib/settingslib.php
+++ b/lib/settingslib.php
@@ -88,7 +88,7 @@ class admin_setting_configmulticheckboxwithicon extends admin_setting_configmult
             //            $options[] = '<input type="checkbox" id="'.$this->get_id().'_'.$key.'" name="'.$this->get_full_name().'['.$key.']" value="1" '.$checked.' />'
             //                .'<label for="'.$this->get_id().'_'.$key.'">'.highlightfast($query, $description).'</label>';
             $options[] = '<input type="checkbox" id="' . $this->get_id() . '_' . $key . '" name="' . $this->get_full_name() . '[' .
-                    $key . ']" value="1" ' . $checked . ' />'
+                    $key . ']" value="1" ' . $checked . ' class="mr-1"/>'
                     . '<label for="' . $this->get_id() . '_' . $key . '">' . $this->icons[$key] .
                     highlightfast($query, $description) . '</label>';
         }


### PR DESCRIPTION
Before
<img width="526" alt="image" src="https://github.com/donhinkelman/moodle-block_sharing_cart/assets/377279/4a1cf348-10cb-4516-8a58-06e39b10f224">

After
<img width="551" alt="image" src="https://github.com/donhinkelman/moodle-block_sharing_cart/assets/377279/fa8a44dc-3350-45bb-909a-b313f6c691fe">
