### PR TITLE
Fixed issue with activity copy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Change Log
 * 4.3, release 1 2023.11.01
   * Adapted Sharing Cart to new core Moodle 4.3 Backup feature which allows backup without editing the backup.
 * 4.2, release skipped.
+* 4.1, release 4 2024.02.27
+  * Fixed issue with activity copy button, where only activities from section 0 would be shown
 * 4.1, release 3 2023.09.20
   * Added activity copy button, if user has capability to back up activities, but not to manage activities 
 * 4.1, release 2 2023.07.05

--- a/block_sharing_cart.php
+++ b/block_sharing_cart.php
@@ -70,7 +70,8 @@ class block_sharing_cart extends block_base {
     public function get_content() {
         global $USER, $COURSE, $PAGE;
 
-        $section_id = optional_param('section', 0, PARAM_INT);
+        $section_id = optional_param('sectionid', null, PARAM_INT);
+        $section_section = optional_param('section', null, PARAM_INT);
 
         $context = context_course::instance($this->page->course->id);
 
@@ -168,13 +169,13 @@ class block_sharing_cart extends block_base {
                 }
             }
 
-            $footer .= $this->insert_copy_section_in_footer($section_id, $sections_dropdown);
+            $footer .= $this->insert_copy_section_in_footer($section_section, $sections_dropdown);
 
             if (!has_capability('moodle/course:manageactivities', $context)) {
                 $activities_dropdown = '';
                 /** @var cm_info $activity */
                 foreach ($activities as $activity) {
-                    if ($this->is_activity_not_in_section($section_id, $activity)) {
+                    if (!$this->is_activity_in_section($section_id, $section_section, $activity)) {
                         continue;
                     }
 
@@ -206,15 +207,31 @@ class block_sharing_cart extends block_base {
         return $this->content = (object) array('text' => $html, 'footer' => $footer);
     }
 
-    private function is_activity_not_in_section(int $section_id, cm_info $activity): bool {
-        return $section_id !== $activity->get_section_info()->section;
+    private function is_activity_in_section(?int $section_id, ?int $section, cm_info $activity): bool {
+        $activity_section = $activity->get_section_info()->section;
+        $activity_id = $activity->get_section_info()->id;
+
+        if ($section === null && $section_id === null) {
+            return true;
+        }
+
+        return $this->is_activity_section_set($section, $activity_section)
+            || $this->is_activity_section_id_set($section_id, $activity_id);
+    }
+
+    private function is_activity_section_set(?int $section, int $activity_section): bool {
+        return $section === $activity_section;
+    }
+
+    private function is_activity_section_id_set(?int $section_id, int $activity_section_id): bool {
+        return $section_id == $activity_section_id;
     }
 
     private function is_activity_deletion_in_progress(cm_info $activity): bool {
         return $activity->deletioninprogress == 1;
     }
 
-    private function insert_copy_section_in_footer(int $section_id, string $sections_dropdown): string {
+    private function insert_copy_section_in_footer(?int $section_id, string $sections_dropdown): string {
         if (!get_config('block_sharing_cart', 'show_copy_section_in_block')) {
             return "";
         }

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die;
 
 /** @var object $plugin */
 $plugin->component = 'block_sharing_cart';
-$plugin->version   = 2024020600;
+$plugin->version   = 2024022700;
 $plugin->requires  = 2023042400; // Moodle 4.2.0
 $plugin->release   = '4.4, release 4';
 $plugin->maturity  = MATURITY_STABLE;


### PR DESCRIPTION
The activity copy button did not look at the section id on the courses correctly, this has now been fixed and should work on all course format in Moodle

(This has been "backported" to Moodle 4.1, which is the reason that no new release number has been added in the version directly, but info is given in the README.md)