### PR TITLE
5.0, release 6 2025.09.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Change Log
     * Added a CLI script to delete all the items from the sharing cart.
     * Fix an issue when restoring non-local backup files.
     * Fixed an issue where sharing cart backups would show up in the moodle core backup UI
+    * Renamed sharing cart backup/restore tasks to differ from core tasks
 * 5.0, release 5 2025.07.02
     * Changed block/sharing_cart:manual_run_task capability to prevent as default for all users.
 * 5.0, release 4 2025.06.20

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Change Log
 * 5.0, release 6 2025.09.24
     * Added a CLI script to delete all the items from the sharing cart.
     * Fix an issue when restoring non-local backup files.
+    * Fixed an issue where sharing cart backups would show up in the moodle core backup UI
 * 5.0, release 5 2025.07.02
     * Changed block/sharing_cart:manual_run_task capability to prevent as default for all users.
 * 5.0, release 4 2025.06.20

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@ Sharing Cart
 
 Purpose
 -------
+
 * The Sharing Cart is a block that enables sharing of Moodle content
   (resources, activities and sections) between multiple courses on your site.
 * You can share among teachers or among your own courses.
 * It can copy single course items and sections, with or without user data.
-  - similar to the "Import" function in Course Administration.
+    - similar to the "Import" function in Course Administration.
 * Items can be collected and saved on the Sharing Cart indefinitely,
   serving as a library of frequently used course items available for duplication.
-  This creates an accumulation of files in the cart, so periodic bulk deletion manually is needed. 
+  This creates an accumulation of files in the cart, so periodic bulk deletion manually is needed.
 
 Requirements
 ------------
@@ -34,6 +35,7 @@ Capabilities
 
 Events
 ------
+
 - block_sharing_cart/backup_course_module
     - Triggered when a course module is added to the Sharing Cart.
 - block_sharing_cart/backup_section
@@ -45,17 +47,18 @@ Events
 
 Versions
 -------
+
 * Version 1:
-  * Items added from block_sharing_cart_sections & block_sharing_cart (pre-5.0 upgrade).
-    Activities are grouped to simulate sections. Backups are individual files.
+    * Items added from block_sharing_cart_sections & block_sharing_cart (pre-5.0 upgrade).
+      Activities are grouped to simulate sections. Backups are individual files.
 * Version 2:
-  * Items added in 5.0 release 1. Uses TYPE_1SECTION for sections and TYPE_1ACTIVITY for activities.
+    * Items added in 5.0 release 1. Uses TYPE_1SECTION for sections and TYPE_1ACTIVITY for activities.
 * Version 3:
-  * Items added in 5.0 release 1+. Uses TYPE_1COURSE for both sections and activities. TYPE_1SECTION and
-    TYPE_1ACTIVITY backups have proven unreliable; TYPE_1COURSE offers more stable backup/restore functionality.
+    * Items added in 5.0 release 1+. Uses TYPE_1COURSE for both sections and activities. TYPE_1SECTION and
+      TYPE_1ACTIVITY backups have proven unreliable; TYPE_1COURSE offers more stable backup/restore functionality.
 * Version 4:
-  * Items added in 5.0 release 4+. Uses TYPE_1COURSE for sections and TYPE_1ACTIVITY for activities.
-    TYPE_1ACTIVITY for activities was to avoid copying all question banks from the course.
+    * Items added in 5.0 release 4+. Uses TYPE_1COURSE for sections and TYPE_1ACTIVITY for activities.
+      TYPE_1ACTIVITY for activities was to avoid copying all question banks from the course.
 
 Important: This versioning helps users identify legacy sharing cart items.
 As of 6.0 release 1, restoration of Legacy items is still supported.
@@ -66,15 +69,21 @@ GPL v3
 
 Change Log
 ----------
+
+* 5.0, release 6 2025.09.24
+    * Added a CLI script to delete all the items from the sharing cart.
+    * Fix an issue when restoring non-local backup files.
 * 5.0, release 5 2025.07.02
     * Changed block/sharing_cart:manual_run_task capability to prevent as default for all users.
 * 5.0, release 4 2025.06.20
     * Change language strings
     * Fixed question bank backup & restore process. Includes question bank only when an activity have dependency on it.
     * Fixed minor issues that caused session lock.
-    * Added capability block/sharing_cart:manual_run_task to allow specific user to manually run the backup/restore task. By default, this capability is set to allow for the manager role archetype.
+    * Added capability block/sharing_cart:manual_run_task to allow specific user to manually run the backup/restore
+      task. By default, this capability is set to allow for the manager role archetype.
     * Added a warning message when backing up a section with mod_quiz.
-    * Switched backup method when copying a single activity to use the activity type backup instead of the course type backup to avoid copying all the question banks from the course.
+    * Switched backup method when copying a single activity to use the activity type backup instead of the course type
+      backup to avoid copying all the question banks from the course.
 * 5.0, release 3 2025.04.22
     * Major changes
         * Changed the section and activity backups to use the course type backup.
@@ -92,9 +101,9 @@ Change Log
           depended on if they were inserted doing the upgrade that also created the block_sharing_cart_items or later.
         * Old sharing cart items and sections will be marked with a blue info icon.
 * 5.0, release 2 2025.04.22
-    * 	Merge pull request #225 from catalyst/issue-224
-    * 	Merge pull request #228 from mgerszew/MOODLE_42_STABLE!
-    * 	Other minor updates and consistant version numbering
+    * Merge pull request #225 from catalyst/issue-224
+    * Merge pull request #228 from mgerszew/MOODLE_42_STABLE!
+    * Other minor updates and consistant version numbering
 * 5.0, release 1 2024.08.05
     * Total refactor of the whole plugin:
         * Improvements

--- a/classes/app/item/repository.php
+++ b/classes/app/item/repository.php
@@ -242,4 +242,9 @@ class repository extends \block_sharing_cart\app\repository
             )
         )[0] ?? null;
     }
+
+    public function get_count(): int
+    {
+        return $this->db->count_records($this->get_table());
+    }
 }

--- a/classes/task/asynchronous_backup_task.php
+++ b/classes/task/asynchronous_backup_task.php
@@ -446,4 +446,9 @@ class asynchronous_backup_task extends \core\task\adhoc_task
 
         $question_bank_setting->set_status($status);
     }
+
+    public function get_name(): string
+    {
+        return parent::get_name() . ' (block_sharing_cart)';
+    }
 }

--- a/classes/task/asynchronous_backup_task.php
+++ b/classes/task/asynchronous_backup_task.php
@@ -62,11 +62,13 @@ class asynchronous_backup_task extends \core\task\adhoc_task
                 }
 
                 $this->controller = \backup_controller::load_controller($backupid);
-                $this->controller->set_progress(new \core\progress\db_updater(
-                    $record->id,
-                    'backup_controllers',
-                    'progress'
-                ));
+                $this->controller->set_progress(
+                    new \core\progress\db_updater(
+                        $record->id,
+                        'backup_controllers',
+                        'progress'
+                    )
+                );
             }
             return $this->controller;
         } catch (\Exception) {
@@ -126,7 +128,9 @@ class asynchronous_backup_task extends \core\task\adhoc_task
                 // If status isn't 700, it means the process has failed.
                 // Retrying isn't going to fix it, so marked operation as failed.
                 $bc->set_status(\backup::STATUS_FINISHED_ERR);
-                $this->output('Bad backup controller status, is: ' . $status . ' should be 700, marking job as failed.');
+                $this->output(
+                    'Bad backup controller status, is: ' . $status . ' should be 700, marking job as failed.'
+                );
             }
 
             $this->after_backup_finished_hook($bc);
@@ -265,6 +269,9 @@ class asynchronous_backup_task extends \core\task\adhoc_task
             $this->output("Copying backup file into sharing cart...");
             $sharing_cart_file = $this->copy_backup_file_to_sharing_cart_filearea($file, $root_item);
 
+            $this->output("Deleting original backup file...");
+            $file->delete();
+
             $this->output("Updating items in sharing cart using contents of backup file...");
             $this->factory()->item()->repository()->update_sharing_cart_item_with_backup_file(
                 $root_item,
@@ -329,7 +336,7 @@ class asynchronous_backup_task extends \core\task\adhoc_task
                         'visible' => true
                     ]) !== false;
 
-                if ($include_activity === false){
+                if ($include_activity === false) {
                     $this->output('...' . ("Excluding activity: (id: $cm_id)"));
                     $task->get_setting('included')->set_value(false);
                 }
@@ -363,8 +370,7 @@ class asynchronous_backup_task extends \core\task\adhoc_task
     private function get_course_modules_settings_by_item(
         int $course_id,
         entity $item
-    ): array
-    {
+    ): array {
         try {
             $item_id = $item->get_old_instance_id();
             if (empty($item_id)) {
@@ -382,7 +388,6 @@ class asynchronous_backup_task extends \core\task\adhoc_task
                 $cms = array_map(static function ($id) {
                     return (int)$id;
                 }, explode(',', $section->sequence));
-
             } else {
                 $cms[] = $item_id;
             }
@@ -395,15 +400,14 @@ class asynchronous_backup_task extends \core\task\adhoc_task
             }
             return $settings;
         } catch (\Exception) {
-             return [];
+            return [];
         }
     }
 
     private function toggle_question_bank_setting(
         \backup_plan $plan,
         entity $item
-    ): void
-    {
+    ): void {
         if (!$plan->setting_exists('questionbank')) {
             return;
         }

--- a/classes/task/asynchronous_restore_task.php
+++ b/classes/task/asynchronous_restore_task.php
@@ -91,7 +91,6 @@ class asynchronous_restore_task extends \core\task\adhoc_task
                 $started,
                 $finished
             );
-
         } catch (\Exception $e) {
             // If an exception is thrown, mark the restore as failed.
             $rc->set_status(\backup::STATUS_FINISHED_ERR);
@@ -273,8 +272,7 @@ class asynchronous_restore_task extends \core\task\adhoc_task
         \restore_section_task $task,
         int $started,
         int $finished
-    ): void
-    {
+    ): void {
         $event = \block_sharing_cart\event\restored_section::create_by_section(
             $task->get_courseid(),
             $task->get_sectionid(),
@@ -283,5 +281,10 @@ class asynchronous_restore_task extends \core\task\adhoc_task
             $finished
         );
         $event->trigger();
+    }
+
+    public function get_name(): string
+    {
+        return parent::get_name() . ' (block_sharing_cart)';
     }
 }

--- a/cli/delete_all_from_sharing_cart.php
+++ b/cli/delete_all_from_sharing_cart.php
@@ -1,0 +1,77 @@
+<?php
+
+const CLI_SCRIPT = true;
+
+require __DIR__ . '/../../../config.php';
+
+global $CFG, $DB;
+require_once($CFG->libdir . "/clilib.php");
+
+// Supported options.
+$long = ['execute' => false, 'help' => false];
+$short = ['e' => 'execute', 'h' => 'help'];
+
+// CLI options.
+[$options, $unrecognized] = cli_get_params($long, $short);
+
+if ($unrecognized) {
+    $unrecognized = implode("\n  ", $unrecognized);
+    cli_error(get_string('cliunknowoption', 'admin', $unrecognized));
+}
+
+if ($options['help']) {
+    $help = <<<EOT
+Deletes all items from sharing cart.
+
+  This script deletes all items from sharing cart for all users.
+
+Options:
+  -h, --help    Print out this help.
+  -e, --execute Run the deletion
+                If not specified only check and report problems to STDERR.
+
+Usage:
+  - Only report:    \$ sudo -u www-data /usr/bin/php blocks/sharing_cart/cli/delete_all_from_sharing_cart.php
+  - Report and fix: \$ sudo -u www-data /usr/bin/php blocks/sharing_cart/cli/delete_all_from_sharing_cart.php -e
+EOT;
+
+    cli_writeln($help);
+    die;
+}
+
+$is_dry_run = $options['execute'] === false;
+
+cli_heading('Checking amount of items in sharing cart across all users');
+$base_factory = \block_sharing_cart\app\factory::make();
+
+$item_count = $base_factory->item()->repository()->get_count();
+cli_writeln("Found {$item_count} items in the sharing cart.");
+
+if ($is_dry_run) {
+    die();
+}
+
+if ($item_count === 0) {
+    cli_writeln("Nothing to delete. Aborting...");
+    die();
+}
+
+cli_heading('Proceeding with deletion of all items in sharing cart across all users');
+
+$failed_deletions = 0;
+
+$records = $DB->get_recordset($base_factory->item()->repository()->get_table(), fields: 'id');
+foreach ($records as $record) {
+    try {
+        cli_writeln("Deleting item with id {$record->id} from sharing cart...");
+        $base_factory->item()->repository()->delete_by_id($record->id);
+    } catch (\Exception $e) {
+        cli_writeln(
+            "Failed to delete item with id {$record->id} from sharing cart. Error: {$e->getMessage()} Trace: {$e->getTraceAsString()}"
+        );
+        $failed_deletions++;
+    }
+}
+$records->close();
+
+cli_writeln("Deletion process completed. {$failed_deletions} items couldn't be deleted.");

--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'block_sharing_cart';
-$plugin->version = 2025070200;
+$plugin->version = 2025092400;
 $plugin->requires = 2023042400; // Moodle 4.2.0
-$plugin->release = '5.0, release 5';
+$plugin->release = '5.0, release 6';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Changes:
* 5.0, release 6 2025.09.24
    * Added a CLI script to delete all the items from the sharing cart.
    * Fix an issue when restoring non-local backup files. (Thx https://github.com/andrewhancox)
      - https://github.com/donhinkelman/moodle-block_sharing_cart/issues/260
    * Fixed an issue where sharing cart backups would show up in the moodle core backup UI. 
      - https://github.com/donhinkelman/moodle-block_sharing_cart/issues/230
    * Renamed sharing cart backup/restore tasks to differ from core tasks
      - https://github.com/donhinkelman/moodle-block_sharing_cart/issues/251